### PR TITLE
fetch-secrets: add secret rotation ticker

### DIFF
--- a/cmd/fetch-secrets/main.go
+++ b/cmd/fetch-secrets/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	smsecrets "github.com/skroutz/aws-lambda-secrets/internal/smsecrets"
 	extension "github.com/skroutz/aws-lambda-secrets/pkg/extension"
@@ -18,12 +19,18 @@ const DEFAULT_TIMEOUT = 5000
 const DEFAULT_REGION = "eu-central-1"
 const SECRETS_FILE = "/var/task/secrets.yaml"
 const OUTPUT_FILE = "/tmp/lambda-secrets.env"
+const SECRETS_CACHE_ENABLED = true
+const SECRETS_CACHE_TTL = 10
 
 var (
 	secretsFile    string
 	region         string
 	timeout        int
 	outputFileName string
+	cacheTTL       time.Duration
+
+	// Cache init
+	cacheEnabled = true
 
 	// extension name has to match the filename
 	extensionName   = filepath.Base(os.Args[0])
@@ -40,6 +47,8 @@ func getCommandParams() {
 		"The YAML file containing SecretsManager ARNs and Env Var names")
 	flag.StringVar(&outputFileName, "o", OUTPUT_FILE,
 		"The file that will be populated with SecretsManager secrets as Env Vars")
+	flag.DurationVar(&cacheTTL, "c", SECRETS_CACHE_TTL,
+		"The cache TTL that defines the time window to re-fetch secrets. Setting it to < 0 will disable caching.")
 	// Parse all of the command line args into the specified vars with the defaults
 	flag.Parse()
 }
@@ -67,6 +76,12 @@ func processEvents(ctx context.Context) {
 	}
 }
 
+func writeSecretsOnDisk(sm *smsecrets.SecretsManager) {
+	secretArns := smsecrets.GetSecretArns(secretsFile)
+	sm.FetchSecrets(secretArns["secrets"])
+	smsecrets.WriteEnvFile(outputFileName)
+}
+
 // This function is only invoked on cold starts
 func main() {
 
@@ -74,17 +89,35 @@ func main() {
 	getCommandParams()
 
 	sm = smsecrets.NewSecretsManager(region, timeout)
-	secretArns := smsecrets.GetSecretArns(secretsFile)
-	sm.FetchSecrets(secretArns["secrets"])
-	smsecrets.WriteEnvFile(outputFileName)
+	writeSecretsOnDisk(sm)
 
 	// Lambda API client context
 	ctx, cancel := context.WithCancel(context.Background())
+
+	// Enable cache
+	if cacheTTL <= 0 {
+		cacheEnabled = false
+	}
+
+	// Re-Fetch cached secrets on cache TTL timeout
+	var ticker *time.Ticker
+	if cacheEnabled {
+		ticker = time.NewTicker(cacheTTL * time.Minute)
+		go func() {
+			c := <-ticker.C
+			log.Printf("[extension] Cache Timeout: %s. Refreshing secrets !\n", c)
+			writeSecretsOnDisk(sm)
+		}()
+	}
+
 	// Handle OS signals to cancel the context before terminating the extension process
 	interruptChannel := make(chan os.Signal, 1)
 	signal.Notify(interruptChannel, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		s := <-interruptChannel
+		if cacheEnabled {
+			ticker.Stop()
+		}
 		log.Println("[extension] Received Signal: ", s)
 		log.Println("[extension] Exiting")
 		cancel()


### PR DESCRIPTION
This commit introduces a ticker go routine responsible for re-fetching and updating secret values from Secrets Manager API to detect and handle secret rotation between Lambda cold starts